### PR TITLE
Feature request: multiple sample compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,41 @@ Nextflow workflow for variant interpretation for precision cancer medicine using
 The Personal Cancer Genome Reporter (PCGR) is a stand-alone software package for functional annotation and translation of individual cancer genomes for precision cancer medicine. Currently, it interprets both somatic SNVs/InDels and copy number aberrations. The software extends basic gene and variant annotations from the [Ensembl’s Variant Effect Predictor (VEP)](http://www.ensembl.org/info/docs/tools/vep/index.html) with oncology-relevant, up-to-date annotations retrieved flexibly through [vcfanno](https://github.com/brentp/vcfanno), and produces interactive HTML reports intended for clinical interpretation.
 
 ## Requirements
-This workflow requires at least 4 cpus and 8GB of memory.
+This workflow requires at least 16 CPUs and 20GB of memory.
 
 ## Usage
 The typical command for running the pipeline is as follows:
-
-    nextflow run main.nf --input sample.csv [Options]
     
-    Inputs Options:
-    --input         Input file
+    nextflow run main.nf --vcf sample.vcf [Options]
+    
+    Essential paramenters:
+        Single File Mode:
+    --vcf           Input `VCF` file.
+                    See example in `testdata/test.vcf`. 
+
+        Multiple File Mode:
+    --csv           A list of `VCF` files.
+                    Should be a `*.csv` file with a header called `vcf` and the path to each file, one per line. 
+                    See example in `testdata/list-vcf-files-local.csv`. 
 
     PCGR Options:
     --pcgr_config   Tool config file (path)
-                    (default: $params.pcgr_config)
+                    (default: s3://fast-ngs/cloudos-public-data-ines/pcgr.toml)
     --pcgr_data     URL for reference data bundle
-                    (default: $params.pcgr_data)
+                    (default: s3://fast-ngs/cloudos-public-data-ines/pcgr)
     --pcgr_genome   Reference genome assembly
-                    (default: $params.pcgr_genome)
+                    (default: grch38)
 
     Resource Options:
     --max_cpus      Maximum number of CPUs (int)
-                    (default: $params.max_cpus)  
+                    (default: 16)  
     --max_memory    Maximum memory (memory unit)
-                    (default: $params.max_memory)
+                    (default: 20 GB)
     --max_time      Maximum time (time unit)
-                    (default: $params.max_time)
+                    (default: 10d)
 
 ## Basic run command example
-    nextflow run main.nf
+    nextflow run main.nf --vcf sample.vcf
 
 ## Run test
     nextflow run main.nf -profile test,<docker...>

--- a/bin/filtervcf.py
+++ b/bin/filtervcf.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+
+def __main__():
+
+    vcf = sys.argv[1]
+    min_qd = sys.argv[2]
+    max_fs = sys.argv[3]
+    max_sor = sys.argv[4]
+    min_mq = sys.argv[5]
+
+    filterstr = ""
+    if 'ID=QD' in open(vcf).read():
+        filterstr += "QD > {}".format(min_qd)
+    if 'ID=FS' in open(vcf).read():
+        if filterstr == "":
+            filterstr += "FS < {}".format(max_fs)
+        else:
+            filterstr += " | FS < {}".format(max_fs)
+    if 'ID=SOR' in open(vcf).read():
+        if filterstr == "":
+            filterstr += "SOR < {}".format(max_sor)
+        else:
+            filterstr += " | SOR < {}".format(max_sor)
+    if 'ID=MQ' in open(vcf).read():
+        if filterstr == "":
+            filterstr += "MQ > {}".format(min_mq)
+        else:
+            filterstr += " | MQ > {}".format(min_mq)
+    
+    with open("filter", "w") as fh:
+        fh.write(filterstr)   
+
+
+if __name__=="__main__": __main__()

--- a/bin/pcgr.toml
+++ b/bin/pcgr.toml
@@ -1,0 +1,77 @@
+# Basic PCGR configuration options (TOML).
+
+[tumor_only]
+## Variant filtering applied for option --tumor_only = true in pcgr.py
+## Several filters can be configured, all as a means to minimize the proportion of germline calls in the raw set derived from tumor-only calling
+
+## Exclude variants (SNVs/InDels) with minor allele frequency above the following population-specific thresholds
+## 1000 Genomes Project - WGS data
+maf_onekg_eur = 0.002
+maf_onekg_amr = 0.002
+maf_onekg_afr = 0.002
+maf_onekg_sas = 0.002
+maf_onekg_eas = 0.002
+maf_onekg_global = 0.002
+
+## exclude variants with minor allele frequency above the following population-specific thresholds
+## gnomAD - WES data
+maf_gnomad_nfe = 0.002
+maf_gnomad_amr = 0.002
+maf_gnomad_afr = 0.002
+maf_gnomad_asj = 0.002
+maf_gnomad_sas = 0.002
+maf_gnomad_eas = 0.002
+maf_gnomad_fin = 0.002
+maf_gnomad_oth = 0.002
+maf_gnomad_global = 0.002
+
+## Exclude variants occurring in PoN (panel of normals, if provided as VCF)
+exclude_pon = true
+
+## Exclude likely homozygous germline variants (100% allelic fraction for alternate allele in tumor, very unlikely somatic event)
+exclude_likely_hom_germline = false
+
+## Exclude likely heterozygous germline variants
+## Must satisfy i) 40-60 % allelic fraction for alternate allele in tumor sample, ii) present in dbSNP + gnomAD, ii) not existing as somatic event in COSMIC/TCGA
+## Note that the application of this filter may be suboptimal for very impure tumors or variants affected by CNAs etc (under these circumstances, the allelic fraction
+## will be skewed (see e.g. discussion in PMID:29249243)
+exclude_likely_het_germline = false
+
+## Exclude variants found in dbSNP (only those that are NOT found in ClinVar(somatic origin)/DoCM/TCGA/COSMIC)
+exclude_dbsnp_nonsomatic = false
+
+## exclude all non-exonic variants
+exclude_nonexonic = true
+
+[allelic_support]
+## Specify INFO tags in input VCF that denotes depth/allelic fraction in tumor and normal sample
+## An additional tag that denotes call confidence (call_conf_tag) can also be specified, which will
+## be used for exploration in the global variant browser. Note that 'tumor_dp_tag' must be of
+## Type=Integer, and 'tumor_af_tag' must be of Type=Float (similarly for normal sample)
+tumor_dp_tag = ""
+tumor_af_tag = ""
+control_dp_tag = ""
+control_af_tag = ""
+call_conf_tag = ""
+
+[visual]
+## Choose visual theme of report, any of: "default", "cerulean", "journal", "flatly", "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone", "simplex", or "yeti" (https://bootswatch.com/)
+report_theme = "default"
+
+[custom_tags]
+## list VCF info tags that should be present in JSON and TSV output
+## tags should be comma separated, i.e. custom_tags = "MUTECT2_FILTER,STRELKA_FILTER"
+custom_tags = ""
+
+[other]
+## list/do not list noncoding variants
+list_noncoding = true
+## VEP/vcfanno processing options
+n_vcfanno_proc = 4
+n_vep_forks = 4
+## Customise the order of criteria used to pick the primary transcript in VEP (see https://www.ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_pick_order)
+vep_pick_order = "canonical,appris,biotype,ccds,rank,tsl,length,mane"
+## omit intergenic variants during VEP processing
+vep_skip_intergenic = false
+## generate a MAF for input VCF using https://github.com/mskcc/vcf2maf
+vcf2maf = true

--- a/bin/pcgr.toml
+++ b/bin/pcgr.toml
@@ -6,72 +6,72 @@
 
 ## Exclude variants (SNVs/InDels) with minor allele frequency above the following population-specific thresholds
 ## 1000 Genomes Project - WGS data
-maf_onekg_eur = 0.002
-maf_onekg_amr = 0.002
-maf_onekg_afr = 0.002
-maf_onekg_sas = 0.002
-maf_onekg_eas = 0.002
-maf_onekg_global = 0.002
+maf_onekg_eur = maf_onekg_eur_placeholder
+maf_onekg_amr = maf_onekg_amr_placeholder
+maf_onekg_afr = maf_onekg_afr_placeholder
+maf_onekg_sas = maf_onekg_sas_placeholder
+maf_onekg_eas = maf_onekg_eas_placeholder
+maf_onekg_global = maf_onekg_global_placeholder
 
 ## exclude variants with minor allele frequency above the following population-specific thresholds
 ## gnomAD - WES data
-maf_gnomad_nfe = 0.002
-maf_gnomad_amr = 0.002
-maf_gnomad_afr = 0.002
-maf_gnomad_asj = 0.002
-maf_gnomad_sas = 0.002
-maf_gnomad_eas = 0.002
-maf_gnomad_fin = 0.002
-maf_gnomad_oth = 0.002
-maf_gnomad_global = 0.002
+maf_gnomad_nfe = maf_gnomad_nfe_placeholder
+maf_gnomad_amr = maf_gnomad_amr_placeholder
+maf_gnomad_afr = maf_gnomad_afr_placeholder
+maf_gnomad_asj = maf_gnomad_asj_placeholder
+maf_gnomad_sas = maf_gnomad_sas_placeholder
+maf_gnomad_eas = maf_gnomad_eas_placeholder
+maf_gnomad_fin = maf_gnomad_fin_placeholder
+maf_gnomad_oth = maf_gnomad_oth_placeholder
+maf_gnomad_global = maf_gnomad_global_placeholder
 
 ## Exclude variants occurring in PoN (panel of normals, if provided as VCF)
-exclude_pon = true
+exclude_pon = exclude_pon_placeholder
 
 ## Exclude likely homozygous germline variants (100% allelic fraction for alternate allele in tumor, very unlikely somatic event)
-exclude_likely_hom_germline = false
+exclude_likely_hom_germline = exclude_likely_hom_germline_placeholder
 
 ## Exclude likely heterozygous germline variants
 ## Must satisfy i) 40-60 % allelic fraction for alternate allele in tumor sample, ii) present in dbSNP + gnomAD, ii) not existing as somatic event in COSMIC/TCGA
 ## Note that the application of this filter may be suboptimal for very impure tumors or variants affected by CNAs etc (under these circumstances, the allelic fraction
 ## will be skewed (see e.g. discussion in PMID:29249243)
-exclude_likely_het_germline = false
+exclude_likely_het_germline = exclude_likely_het_germline_placeholder
 
 ## Exclude variants found in dbSNP (only those that are NOT found in ClinVar(somatic origin)/DoCM/TCGA/COSMIC)
-exclude_dbsnp_nonsomatic = false
+exclude_dbsnp_nonsomatic = exclude_dbsnp_nonsomatic_placeholder
 
 ## exclude all non-exonic variants
-exclude_nonexonic = true
+exclude_nonexonic = exclude_nonexonic_placeholder
 
 [allelic_support]
 ## Specify INFO tags in input VCF that denotes depth/allelic fraction in tumor and normal sample
 ## An additional tag that denotes call confidence (call_conf_tag) can also be specified, which will
 ## be used for exploration in the global variant browser. Note that 'tumor_dp_tag' must be of
 ## Type=Integer, and 'tumor_af_tag' must be of Type=Float (similarly for normal sample)
-tumor_dp_tag = ""
-tumor_af_tag = ""
-control_dp_tag = ""
-control_af_tag = ""
-call_conf_tag = ""
+tumor_dp_tag = tumor_dp_tag_placeholder
+tumor_af_tag = tumor_af_tag_placeholder
+control_dp_tag = control_dp_tag_placeholder
+control_af_tag = control_af_tag_placeholder
+call_conf_tag = call_conf_tag_placeholder
 
 [visual]
 ## Choose visual theme of report, any of: "default", "cerulean", "journal", "flatly", "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone", "simplex", or "yeti" (https://bootswatch.com/)
-report_theme = "default"
+report_theme = report_theme_placeholder
 
 [custom_tags]
 ## list VCF info tags that should be present in JSON and TSV output
 ## tags should be comma separated, i.e. custom_tags = "MUTECT2_FILTER,STRELKA_FILTER"
-custom_tags = ""
+custom_tags = custom_tags_placeholder
 
 [other]
 ## list/do not list noncoding variants
-list_noncoding = true
+list_noncoding = list_noncoding_placeholder
 ## VEP/vcfanno processing options
-n_vcfanno_proc = 4
-n_vep_forks = 4
+n_vcfanno_proc = n_vcfanno_proc_placeholder
+n_vep_forks = n_vep_forks_placeholder
 ## Customise the order of criteria used to pick the primary transcript in VEP (see https://www.ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_pick_order)
-vep_pick_order = "canonical,appris,biotype,ccds,rank,tsl,length,mane"
+vep_pick_order = vep_pick_order_placeholder
 ## omit intergenic variants during VEP processing
-vep_skip_intergenic = false
+vep_skip_intergenic = vep_skip_intergenic_placeholder
 ## generate a MAF for input VCF using https://github.com/mskcc/vcf2maf
-vcf2maf = true
+vcf2maf = vcf2maf_placeholder

--- a/bin/report.py
+++ b/bin/report.py
@@ -21,7 +21,7 @@ html_template_top = """
             }
         </script>
     </head>
-    <body style="background-color: #666666">
+    <body style="background-color: #FFFFFF">
         <div id="root">
             <form>
             <select name="list" id="list" accesskey="target">
@@ -37,12 +37,13 @@ html_template_bottom = """
 """
 def __main__():
     
-    pcgr_reports = sys.argv[1].split()
+    pcgr_reports = sys.argv[1:]
+    print(pcgr_reports)
 
     if len(pcgr_reports) == 1:
         shutil.copyfile(pcgr_reports[0], "multiqc_report.html", follow_symlinks=True)
     else:
-        with open("multiqc_report.html", w) as fh:
+        with open("multiqc_report.html", "w") as fh:
             fh.write(html_template_top)
             for report in pcgr_reports:
                 str_option = "                <option value='{0}'>{0}</option>\n".format(report)

--- a/bin/report.py
+++ b/bin/report.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import shutil
+
+def __main__():
+    
+    pcgr_reports = sys.argv[1].split()
+
+    if len(pcgr_reports) == 1:
+        shutil.copyfile(pcgr_reports[0], "multiqc_report.html", follow_symlinks=True)
+    else:
+        shutil.copyfile(pcgr_reports[0], "multiqc_report.html", follow_symlinks=True)
+
+
+if __name__=="__main__": __main__()

--- a/bin/report.py
+++ b/bin/report.py
@@ -4,6 +4,37 @@ import os
 import sys
 import shutil
 
+html_template_top = """
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>PCGR Report</title>
+        <script type="text/javascript">
+            function goToNewPage()
+            {
+                var url = document.getElementById('list').value;
+                if(url != 'none') {
+                    window.location = url;
+                }
+            }
+        </script>
+    </head>
+    <body style="background-color: #666666">
+        <div id="root">
+            <form>
+            <select name="list" id="list" accesskey="target">
+                <option value='none' selected>Choose a report</option>
+"""
+html_template_bottom = """
+            </select>
+            <input type=button value="Go" onclick="goToNewPage()" />
+            </form>
+        </div>
+    </body>
+</html>
+"""
 def __main__():
     
     pcgr_reports = sys.argv[1].split()
@@ -11,7 +42,12 @@ def __main__():
     if len(pcgr_reports) == 1:
         shutil.copyfile(pcgr_reports[0], "multiqc_report.html", follow_symlinks=True)
     else:
-        shutil.copyfile(pcgr_reports[0], "multiqc_report.html", follow_symlinks=True)
+        with open("multiqc_report.html", w) as fh:
+            fh.write(html_template_top)
+            for report in pcgr_reports:
+                str_option = "                <option value='{0}'>{0}</option>\n".format(report)
+                fh.write(str_option)
+            fh.write(html_template_bottom)
 
 
 if __name__=="__main__": __main__()

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,6 +1,10 @@
 params {
     input = 'testdata/test.vcf'
-    name = "testdata"
-    pcgr_config = "testdata/pcgr.toml"
     report_dir = "results" 
+}
+
+process {
+    withName: pcgr {
+        label = 'process_low'
+    }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,5 +1,5 @@
 params {
-    input = 'testdata/test.vcf'
+    csv = 'testdata/test.vcf'
     report_dir = "results" 
 }
 

--- a/main.nf
+++ b/main.nf
@@ -50,7 +50,7 @@ if (params.vcf && params.csv){ exit 1, "Multiple modes selected. Run single file
 
 if (params.vcf){
     Channel
-        .fromPath(params.input)
+        .fromPath(params.vcf)
         .ifEmpty { exit 1, "Cannot find input file : ${params.vcf}" }
         .set { ch_input }
 }

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@ def helpMessage() {
     log.info """
     Usage:
     The typical command for running the pipeline is as follows:
-    nextflow run main.nf --input sample.csv [Options]
+    nextflow run main.nf --vcf sample.vcf [Options]
     
     Essential paramenters:
         Single File Mode:

--- a/main.nf
+++ b/main.nf
@@ -134,6 +134,7 @@ if (!params.skip_filtering) {
 
 process pcgr {
     tag "$input_file"
+    //label 'process_high'
     label 'process_low'
     publishDir "${params.outdir}", mode: 'copy'
 
@@ -189,7 +190,7 @@ process pcgr {
 
     # Run PCGR
     mkdir result
-    pcgr.py --input_vcf $input_file --pcgr_dir $data --output_dir result/ --genome_assembly $reference --conf new_config.toml --sample_id $input_file.baseName --no_vcf_validate --no-docker
+    pcgr.py --tumor_site ${params.pcgr_tumor_site} --input_vcf $input_file --pcgr_dir $data --output_dir result/ --genome_assembly $reference --conf new_config.toml --sample_id $input_file.baseName --no_vcf_validate --no-docker
 
     # Save RMarkdown report
     cp result/*${reference}.html ${input_file.baseName}_pcgr.html
@@ -198,15 +199,15 @@ process pcgr {
 
 process report {
     label 'process_low'
-    publishDir "${params.outdir}/MultiQC", mode: 'copy', pattern: "multiqc_report.html"
+    publishDir "${params.outdir}/MultiQC", mode: 'copy', pattern: "*.html"
 
     input:
     file report from out_pcgr.collect()
     each file("report.py") from run_report
 
-
     output:
     file "*.html"
+    file report
 
     script:
     "python report.py $report"

--- a/main.nf
+++ b/main.nf
@@ -134,8 +134,7 @@ if (!params.skip_filtering) {
 
 process pcgr {
     tag "$input_file"
-    //label 'process_high'
-    label 'process_low'
+    label 'process_high'
     publishDir "${params.outdir}", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -105,7 +105,7 @@ process vcffilter {
 
 process pcgr {
     tag "$input_file"
-    label 'process_low'
+    label 'process_high'
     publishDir "${params.outdir}", mode: 'copy'
 
     input:
@@ -117,6 +117,7 @@ process pcgr {
     output:
     file "*_pcgr.html" into out_pcgr
     file "result/*"
+
     script:
     """
     # Modify config_toml pass the params
@@ -132,7 +133,7 @@ process pcgr {
     sed -i "s/maf_gnomad_nfe_placeholder/${params.maf_gnomad_nfe}/g" new_config.toml
     sed -i "s/maf_gnomad_amr_placeholder/${params.maf_gnomad_amr}/g" new_config.toml
     sed -i "s/maf_gnomad_afr_placeholder/${params.maf_gnomad_afr}/g" new_config.toml
-    sed -i "s/maf_gnomad_asj_placeholder/${params.maf_gnomad_ajs}/g" new_config.toml
+    sed -i "s/maf_gnomad_asj_placeholder/${params.maf_gnomad_asj}/g" new_config.toml
     sed -i "s/maf_gnomad_sas_placeholder/${params.maf_gnomad_sas}/g" new_config.toml
     sed -i "s/maf_gnomad_eas_placeholder/${params.maf_gnomad_eas}/g" new_config.toml
     sed -i "s/maf_gnomad_fin_placeholder/${params.maf_gnomad_fin}/g" new_config.toml
@@ -159,7 +160,7 @@ process pcgr {
 
     # Run PCGR
     mkdir result
-    pcgr.py --input_vcf $input_file --pcgr_dir $data --output_dir result/ --genome_assembly $reference --conf $config_file --sample_id $input_file.baseName --no_vcf_validate --no-docker
+    pcgr.py --input_vcf $input_file --pcgr_dir $data --output_dir result/ --genome_assembly $reference --conf new_config.toml --sample_id $input_file.baseName --no_vcf_validate --no-docker
 
     # Save RMarkdown report
     cp result/*${reference}.html ${input_file.baseName}_pcgr.html
@@ -179,6 +180,6 @@ process report {
     file "multiqc_report.html"
 
     script:
-    "report.py $report"
+    "python report.py $report"
 
 }

--- a/main.nf
+++ b/main.nf
@@ -6,9 +6,15 @@ def helpMessage() {
     The typical command for running the pipeline is as follows:
     nextflow run main.nf --input sample.csv [Options]
     
-    Inputs Options:
-    --input         Input VCF file
-    --name          Sample name
+    Essential paramenters:
+        Single File Mode:
+    --vcf           Input `VCF` file.
+                    See example in `testdata/test.vcf`. 
+
+        Multiple File Mode:
+    --csv           A list of `VCF` files.
+                    Should be a `*.csv` file with a header called `vcf` and the path to each file, one per line. 
+                    See example in `testdata/list-vcf-files-local.csv`.
 
     PCGR Options:
     --pcgr_config   Tool config file (path)
@@ -25,26 +31,38 @@ def helpMessage() {
                     (default: $params.max_memory)
     --max_time      Maximum time (time unit)
                     (default: $params.max_time)
-    See here for more info: https://github.com/lifebit-ai/hla/blob/master/docs/usage.md
+    See here for more info: https://github.com/lifebit-ai/pcgr-nf
     """.stripIndent()
 }
 
 // Show help message
 if (params.help) {
-  helpMessage()
-  exit 0
+    helpMessage()
+    exit 0
 }
 
 // Define Channels from input
-Channel
-    .fromPath(params.input)
-    .ifEmpty { exit 1, "Cannot find input file : ${params.input}" }
-    .set { ch_input }
 
-Channel
-    .from(params.name)
-    .ifEmpty { exit 1, "Cannot find input name : ${params.name}" }
-    .set { sample_name }
+// - Check input mode 
+if (!params.vcf && !params.csv){ exit 1, "Essential parameters missing"}
+
+if (params.vcf && params.csv){ exit 1, "Multiple modes selected. Run single file mode (--vcf and --name) or multiple file (--csv) independently"}
+
+if (params.vcf){
+    Channel
+        .fromPath(params.input)
+        .ifEmpty { exit 1, "Cannot find input file : ${params.vcf}" }
+        .set { ch_input }
+}
+
+if (params.csv){
+    Channel
+        .fromPath(params.csv)
+        .splitCsv(header:true)
+        .map{ row -> file(row.vcf) }
+        .flatten()
+        .set { ch_input }
+}
 
 Channel.fromPath(params.pcgr_data)
     .ifEmpty { exit 1, "Cannot find data bundle path : ${params.pcgr_data}" }
@@ -71,7 +89,7 @@ process vcffilter {
 }
 
 process pcgr {
-    tag "$name"
+    tag "$input_file"
     label 'process_high'
     publishDir "${params.outdir}", mode: 'copy'
     publishDir "${params.outdir}/MultiQC", mode: 'copy', pattern: "multiqc_report.html"
@@ -79,7 +97,6 @@ process pcgr {
     input:
     file input_file from out_vcf_filter
     path data from data_bundle
-    val name from sample_name
     path config_file from config
 
     output:
@@ -88,8 +105,8 @@ process pcgr {
     script:
     """
     mkdir result
-    pcgr.py --input_vcf $input_file --pcgr_dir $data --output_dir result/ --genome_assembly $params.pcgr_genome --conf $config_file --sample_id $name --no_vcf_validate --no-docker
+    pcgr.py --input_vcf $input_file --pcgr_dir $data --output_dir result/ --genome_assembly $params.pcgr_genome --conf $config_file --sample_id $input_file.baseName --no_vcf_validate --no-docker
 
     cp result/*${params.pcgr_genome}.html multiqc_report.html
     """
-  }
+}

--- a/main.nf
+++ b/main.nf
@@ -110,14 +110,14 @@ if (!params.skip_filtering) {
 
 process pcgr {
     tag "$input_file"
-    label 'process_high'
+    label 'process_low'
     publishDir "${params.outdir}", mode: 'copy'
 
     input:
     file input_file from ch_vcf_for_pcgr
-    path data from data_bundle
-    file(config_toml) from pcgr_toml_config
-    val reference from ch_reference
+    each path(data) from data_bundle
+    each file(config_toml) from pcgr_toml_config
+    each reference from ch_reference
 
     output:
     file "*_pcgr.html" into out_pcgr
@@ -182,7 +182,7 @@ process report {
 
 
     output:
-    file "multiqc_report.html"
+    file "*.html"
 
     script:
     "python report.py $report"

--- a/main.nf
+++ b/main.nf
@@ -88,23 +88,23 @@ run_report = Channel.fromPath("${projectDir}/bin/report.py",  type: 'file', foll
 pcgr_toml_config = params.pcgr_config ? Channel.value(file(params.pcgr_config)) : Channel.fromPath("${projectDir}/bin/pcgr.toml", type: 'file', followLinks: false) 
 
 if (!params.skip_filtering) {
-  process vcffilter {
-      tag "$input_file"
-      label 'process_low'
+    process vcffilter {
+        tag "$input_file"
+        label 'process_low'
 
-      input:
-      file input_file from ch_input
+        input:
+        file input_file from ch_input
 
-      output:
-      file "*filtered.vcf" into out_vcf_filter
+        output:
+        file "*filtered.vcf" into out_vcf_filter
 
-      script:
-      """
-      vcffilter -s -f "QD > ${params.min_qd} | FS < ${params.max_fs} | SOR < ${params.max_sor} | MQ > ${params.min_mq}" $input_file > ${input_file.baseName}_filtered.vcf
-      """
-  }
+        script:
+        """
+        vcffilter -s -f "QD > ${params.min_qd} | FS < ${params.max_fs} | SOR < ${params.max_sor} | MQ > ${params.min_mq}" $input_file > ${input_file.baseName}_filtered.vcf
+        """
+    }
 }else{
-  ch_vcf_for_pcgr = ch_input
+    ch_vcf_for_pcgr = ch_input
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -46,7 +46,7 @@ if (params.help) {
 // - Check input mode 
 if (!params.vcf && !params.csv){ exit 1, "Essential parameters missing"}
 
-if (params.vcf && params.csv){ exit 1, "Multiple modes selected. Run single file mode (--vcf and --name) or multiple file (--csv) independently"}
+if (params.vcf && params.csv){ exit 1, "Multiple modes selected. Run single file mode (--vcf) or multiple file (--csv) independently"}
 
 if (params.vcf){
     Channel

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,6 +17,14 @@ params {
     pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr'
     pcgr_genome = 'grch38'
 
+    min_qd = '2'
+    max_fs = '60'
+    max_sor = '3'
+    min_mq = '40'
+    min_mqranksum = '-2.5'
+    min_readposranksum = '-8'
+
+
     // report_dir is:
     // - the folder from the container that includes the scripts for NF <= v20.01 (bin)
     // - the ${projectDir}/bin folder of the root of the repo with the scripts for NF >= v20.10
@@ -85,10 +93,13 @@ process {
     container = params.container
     errorStrategy = params.errorStrategy
   
-    // If your pipeline doesn't include a process named 'step_1', update the name to match your process of choice or delete this block
     withName: pcgr {
         disk = '100.GB'
         container = 'quay.io/lifebitai/pcgr:0.9.1'
+    }
+
+    withName: vcffilter {
+      container = 'quay.io/biocontainers/vcflib:1.0.2--h3198e80_5'
     }
 
     withLabel:process_low {
@@ -108,9 +119,6 @@ process {
     }
     withLabel:process_long {
         time = { check_max( 20.h * task.attempt, 'time' ) }
-    }
-    withName:get_software_versions {
-        cache = false
     }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,6 +30,7 @@ params {
     pcgr_config = 's3://fast-ngs/cloudos-public-data-ines/pcgr.toml'
     pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr'
     pcgr_genome = 'grch38'
+    pcgr_tumor_site = 0
 
     // PCGR configuration parameters
     maf_onekg_eur = 0.002

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,15 +8,14 @@
 // NOTE: 
 // Initialise the values of the params to the preferred default value or to false
 params {
-    // input options
-    input = false
-    name = ''
-    outdir = 'results'
 
-    pcgr_config = 's3://fast-ngs/cloudos-public-data-ines/pcgr.toml'
-    pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr'
-    pcgr_genome = 'grch38'
+    // Essential parameters
+    // - Single VCF file mode
+    vcf = false
+    // - Multiple VCF file mode
+    csv = false
 
+    // VCF filter parameters
     min_qd = '2'
     max_fs = '60'
     max_sor = '3'
@@ -24,6 +23,12 @@ params {
     min_mqranksum = '-2.5'
     min_readposranksum = '-8'
 
+    // PCGR run parameters
+    pcgr_config = 's3://fast-ngs/cloudos-public-data-ines/pcgr.toml'
+    pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr'
+    pcgr_genome = 'grch38'
+
+    outdir = 'results'
 
     // report_dir is:
     // - the folder from the container that includes the scripts for NF <= v20.01 (bin)

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,46 @@ params {
     pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr'
     pcgr_genome = 'grch38'
 
+    // PCGR configuration parameters
+    maf_onekg_eur = 0.002
+    maf_onekg_amr = 0.002
+    maf_onekg_afr = 0.002
+    maf_onekg_sas = 0.002
+    maf_onekg_eas = 0.002
+    maf_onekg_global = 0.002
+
+    maf_gnomad_nfe = 0.002
+    maf_gnomad_amr = 0.002
+    maf_gnomad_afr = 0.002
+    maf_gnomad_asj = 0.002
+    maf_gnomad_sas = 0.002
+    maf_gnomad_eas = 0.002
+    maf_gnomad_fin = 0.002
+    maf_gnomad_oth = 0.002
+    maf_gnomad_global = 0.002
+
+    exclude_pon = true
+    exclude_likely_hom_germline = false
+    exclude_likely_het_germline = false
+    exclude_dbsnp_nonsomatic = false
+    exclude_nonexonic = true
+
+    tumor_dp_tag = ""
+    tumor_af_tag = ""
+    control_dp_tag = ""
+    control_af_tag = ""
+    call_conf_tag = ""
+
+    report_theme = "default"
+    custom_tags = ""
+
+    list_noncoding = true
+    n_vcfanno_proc = 4
+    n_vep_forks = 4
+    vep_pick_order = "canonical,appris,biotype,ccds,rank,tsl,length,mane"
+    vep_skip_intergenic = false
+    vcf2maf = true
+
     outdir = 'results'
 
     // report_dir is:

--- a/testdata/list-json-files-cloudos.csv
+++ b/testdata/list-json-files-cloudos.csv
@@ -1,0 +1,2 @@
+vcf
+s3://fast-ngs/cloudos-public-data-ines/test.vcf

--- a/testdata/list-vcf-files-local.csv
+++ b/testdata/list-vcf-files-local.csv
@@ -1,0 +1,2 @@
+vcf
+testdata/test.vcf

--- a/testdata/list-vcf-files-local.csv
+++ b/testdata/list-vcf-files-local.csv
@@ -1,2 +1,3 @@
 vcf
 testdata/test.vcf
+testdata/two.vcf


### PR DESCRIPTION
This PR makes the following changes:

- the filtering based on QC metrics is optional (and to be refactored to address #8 
- Essential parameters extended to two options: `--vcf` for single vcf analysis and `--csv` for list of vcfs to process
- configuration of pcgr is now totally parameterised 
- for single sample, the pcgr report is displayed in cloudOS. for multiple reports an intermediary html page containing a dropdown is available to select the report of interest to be displayed. 