### PR TITLE
Load appropriate data bundle from reference genome

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ The typical command for running the pipeline is as follows:
     PCGR Options:
     --pcgr_config   Tool config file (path)
                     (default: s3://fast-ngs/cloudos-public-data-ines/pcgr.toml)
-    --pcgr_data     URL for reference data bundle
-                    (default: s3://fast-ngs/cloudos-public-data-ines/pcgr)
     --pcgr_genome   Reference genome assembly
                     (default: grch38)
+    --pcgr_data     URL for reference data bundle
+                    Optional filed. If not provided, the appropriate data bundle is infered from --pcgr_genome. 
+                    (default: false)
 
     Resource Options:
     --max_cpus      Maximum number of CPUs (int)

--- a/main.nf
+++ b/main.nf
@@ -79,29 +79,21 @@ Channel.fromPath(params.pcgr_config)
     .set{ config }
 
 // Check for valid reference options 
-def human_reference_expected = ['grch37', 'grch38'] as Set
-def parameter_diff = human_reference_expected - params.pcgr_genome
-if (parameter_diff.size() > 1){
-        println "[Pipeline warning] Parameter $params.pcgr_genome is not valid in the pipeline! Running with default 'grch38'\n"
-        ch_reference = Channel.value('grch38')
-        if (!params.pcgr_data){
-            data_bundle = Channel.fromPath('s3://fast-ngs/cloudos-public-data-ines/pcgr_data_grch38')
-        }
-    } else {
-        ch_reference = Channel.value(params.pcgr_genome)
-        if (!params.pcgr_data){
-            if (params.pcgr_genome == "grch38"){
-                data_bundle = Channel.fromPath('s3://fast-ngs/cloudos-public-data-ines/pcgr_data_grch38')
-            } else {
-                data_bundle = Channel.fromPath('s3://fast-ngs/cloudos-public-data-ines/pcgr_data_grch37')
-            }
-        }
-    }
+if (!params.genomes.containsKey(params.pcgr_genome)){exit 1, "Error: Parameter $params.pcgr_genome is not valid in the pipeline. Available values: ${params.genomes.keySet().join(", ")}"}
+if (!params.pcgr_data){
+    pcgr_data = params.genomes[params.pcgr_genome].pcgr_data
+} else {
+    pcgr_data = params.pcgr_data
+}
+
+data_bundle = Channel.fromPath(pcgr_data)
+ch_reference = Channel.value(params.pcgr_genome)
+
 
 // Check for valid output mode options 
 def report_expected = ['summary', 'report'] as Set
 def report_parameter_diff = report_expected - params.report_mode
-if (parameter_diff.size() > 1){
+if (report_parameter_diff.size() > 1){
         println "[Pipeline warning] Parameter $params.report_mode is not valid in the pipeline! Running with default 'report'\n"
         report_mode = 'report'
     } else {

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,14 @@ params {
     pcgr_genome = 'grch38'
     pcgr_tumor_site = 0
     pcgr_data = false
+    genomes {
+      'grch38' {
+        pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr_data_grch38'
+      }
+      'grch37' {
+        pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr_data_grch37'
+      }
+    }
 
     // PCGR configuration parameters
     maf_onekg_eur = 0.002

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,9 +21,9 @@ params {
 
     // PCGR run parameters
     pcgr_config = 's3://fast-ngs/cloudos-public-data-ines/pcgr.toml'
-    pcgr_data = 's3://fast-ngs/cloudos-public-data-ines/pcgr'
     pcgr_genome = 'grch38'
     pcgr_tumor_site = 0
+    pcgr_data = false
 
     // PCGR configuration parameters
     maf_onekg_eur = 0.002


### PR DESCRIPTION
This PR sets the `--pcgr_data` parameter as optional. If not provided, the appropriate pcgr data bundle is staged based on the `--pcgr_genome` parameter (either 'grch37' or 'grch38')

Validation on the allowed human reference genome options was already implemented. 