### PR TITLE
Add improvements to summary report

### DIFF
--- a/bin/pivot_gene.py
+++ b/bin/pivot_gene.py
@@ -25,10 +25,11 @@ def process(group_name, df_group):
     Worker function to process the dataframe.
     """
     row = {'SYMBOL'.capitalize(): group_name[0],
-            'VARIANT CLASS'.capitalize(): group_name[1],
-            'CONSEQUENCE'.capitalize(): group_name[2]}
+            'GENE_NAME'.capitalize(): group_name[1],
+            'VARIANT CLASS'.capitalize(): group_name[2],
+            'CONSEQUENCE'.capitalize(): group_name[3]}
     for column in df_group.columns:
-        if column not in ['SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE']:
+        if column not in ['SYMBOL', 'GENE_NAME', 'VARIANT_CLASS', 'CONSEQUENCE']:
             row[column.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group[column].unique())])
     row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'].unique())))
     return row
@@ -36,22 +37,29 @@ def process(group_name, df_group):
 
 def __main__():
 
-    #columns = sys.argv[2].split(',')
     combined = sys.argv[1]
-    max_cpus = int(sys.argv[2])
+    columns = sys.argv[2]
+    if columns == 'false':
+        columns = []
+    else:
+        columns = sys.argv[2].split(',')
+    max_cpus = int(sys.argv[3])
+
+    mandatory_columns = ['GENE_NAME','SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE', 'ONCOGENE', 'TUMOR_SUPPRESSOR', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
+
     print("Input combined tiers file:", combined)
-    print("Mandatory columns", ['GENE_NAME','SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE'])
-    print("Extra columns to include:")
-    
-    all_columns = ['GENE_NAME','SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
-    
+    print("Mandatory columns", mandatory_columns)
+    print("Extra columns to include:", columns)
+
+    all_columns = list(set(mandatory_columns + columns))
+        
     reader = pd.read_csv(combined, sep='\t', header=0, chunksize=1000, usecols=all_columns)
     chunk_arr = []
     for df in reader:
         chunk_arr.append(df)
     df = pd.concat(chunk_arr, axis=0)
 
-    group_by = df.groupby(['SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE'])
+    group_by = df.groupby(['SYMBOL','GENE_NAME','VARIANT_CLASS','CONSEQUENCE'])
     print("Number of genes found:", len(group_by))
 
     pool = mp.Pool(processes=max_cpus)

--- a/bin/pivot_gene_complete.py
+++ b/bin/pivot_gene_complete.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import shutil
+import pandas as pd
+import multiprocessing as mp
+
+
+PCGR_COLUMNS = ['CHROM','POS','REF','ALT','GENOMIC_CHANGE','GENOME_VERSION','VCF_SAMPLE_ID',
+                'VARIANT_CLASS','SYMBOL','GENE_NAME','CCDS','CANONICAL','ENTREZ_ID','UNIPROT_ID',
+                'ENSEMBL_TRANSCRIPT_ID','ENSEMBL_GENE_I','REFSEQ_MRNA','ONCOGENE','TUMOR_SUPPRESSOR',
+                'ONCOGENE_EVIDENCE','TUMOR_SUPPRESSOR_EVIDENCE','CONSEQUENCE','PROTEIN_CHANGE','PROTEIN_DOMAIN',
+                'CODING_STATUS','EXONIC_STATUS','CDS_CHANGE','HGVSp','HGVSc','EFFECT_PREDICTIONS',
+                'MUTATION_HOTSPOT','MUTATION_HOTSPOT_TRANSCRIPT','MUTATION_HOTSPOT_CANCERTYPE','PUTATIVE_DRIVER_MUTATION',
+                'CHASMPLUS_DRIVER','CHASMPLUS_TTYPE','VEP_ALL_CSQ','DBSNPRSID','COSMIC_MUTATION_ID','TCGA_PANCANCER_COUNT',
+                'TCGA_FREQUENCY','ICGC_PCAWG_OCCURRENCE','CHEMBL_COMPOUND_ID','CHEMBL_COMPOUND_TERMS','SIMPLEREPEATS_HIT',
+                'WINMASKER_HIT','OPENTARGETS_RANK','CLINVAR','CLINVAR_CLNSIG','GLOBAL_AF_GNOMAD','GLOBAL_AF_1KG',
+                'CALL_CONFIDENCE','DP_TUMOR','AF_TUMOR','DP_CONTROL','AF_CONTROL','TIER','TIER_DESCRIPTION']
+
+
+def process(group_name, df_group):
+    """
+    Worker function to process the dataframe.
+    """
+    row = {'SYMBOL'.capitalize(): group_name[0],
+            'GENE_NAME'.capitalize(): group_name[1],
+            'VARIANT CLASS'.capitalize(): group_name[2],
+            'CONSEQUENCE'.capitalize(): group_name[3]}
+    for column in df_group.columns:
+        if column not in ['SYMBOL', 'GENE_NAME', 'VARIANT_CLASS', 'CONSEQUENCE']:
+            row[column.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group[column].unique())])
+    row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'].unique())))
+    return row
+
+
+def __main__():
+
+    combined = sys.argv[1]
+    columns = sys.argv[2]
+    if columns == 'false':
+        columns = []
+    else:
+        columns = sys.argv[2].split(',')
+    max_cpus = int(sys.argv[3])
+
+    mandatory_columns = ['GENE_NAME','SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE', 'ONCOGENE', 'TUMOR_SUPPRESSOR', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
+
+    print("Input combined tiers file:", combined)
+    print("Mandatory columns", mandatory_columns)
+    print("Extra columns to include:", columns)
+
+    all_columns = list(set(mandatory_columns + columns))
+        
+    reader = pd.read_csv(combined, sep='\t', header=0, chunksize=1000, usecols=all_columns)
+    chunk_arr = []
+    for df in reader:
+        chunk_arr.append(df)
+    df = pd.concat(chunk_arr, axis=0)
+
+    group_by = df.groupby(['SYMBOL','GENE_NAME','VARIANT_CLASS','CONSEQUENCE'])
+    print("Number of genes found:", len(group_by))
+
+    pool = mp.Pool(processes=max_cpus)
+    f_list = []
+    for group_name, df_group in group_by:
+        f = pool.apply_async(process, [group_name, df_group])
+        f_list.append(f)
+
+    pivot = pd.DataFrame([f.get() for f in f_list]) 
+    pivot.to_csv("pivot_gene_complete.tsv", sep='\t', index=False)
+
+if __name__=="__main__": __main__()

--- a/bin/pivot_gene_simple.py
+++ b/bin/pivot_gene_simple.py
@@ -25,11 +25,9 @@ def process(group_name, df_group):
     Worker function to process the dataframe.
     """
     row = {'SYMBOL'.capitalize(): group_name[0],
-            'GENE_NAME'.capitalize(): group_name[1],
-            'VARIANT CLASS'.capitalize(): group_name[2],
-            'CONSEQUENCE'.capitalize(): group_name[3]}
+            'GENE_NAME'.capitalize(): group_name[1]}
     for column in df_group.columns:
-        if column not in ['SYMBOL', 'GENE_NAME', 'VARIANT_CLASS', 'CONSEQUENCE']:
+        if column not in ['SYMBOL', 'GENE_NAME', 'GENOMIC_CHANGE']:
             row[column.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group[column].unique())])
     row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'].unique())))
     return row
@@ -45,7 +43,7 @@ def __main__():
         columns = sys.argv[2].split(',')
     max_cpus = int(sys.argv[3])
 
-    mandatory_columns = ['GENE_NAME','SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE', 'ONCOGENE', 'TUMOR_SUPPRESSOR', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
+    mandatory_columns = ['GENE_NAME','SYMBOL', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
 
     print("Input combined tiers file:", combined)
     print("Mandatory columns", mandatory_columns)
@@ -59,7 +57,7 @@ def __main__():
         chunk_arr.append(df)
     df = pd.concat(chunk_arr, axis=0)
 
-    group_by = df.groupby(['SYMBOL','GENE_NAME','VARIANT_CLASS','CONSEQUENCE'])
+    group_by = df.groupby(['SYMBOL','GENE_NAME'])
     print("Number of genes found:", len(group_by))
 
     pool = mp.Pool(processes=max_cpus)
@@ -69,6 +67,6 @@ def __main__():
         f_list.append(f)
 
     pivot = pd.DataFrame([f.get() for f in f_list]) 
-    pivot.to_csv("pivot_gene.tsv", sep='\t', index=False)
+    pivot.to_csv("pivot_gene_simple.tsv", sep='\t', index=False)
 
 if __name__=="__main__": __main__()

--- a/bin/pivot_variant.py
+++ b/bin/pivot_variant.py
@@ -25,6 +25,7 @@ def process(group_name, df_group):
     """
     row = {'GENOMIC CHANGE'.capitalize(): group_name}
     for column in df_group.columns:
+        df_group[column] = df_group[column].apply(str)
         row[column.replace('_', ' ').capitalize()] = ";".join(list(df_group[column].unique()))
     return row
 
@@ -35,10 +36,10 @@ def __main__():
     combined = sys.argv[1]
     max_cpus = int(sys.argv[3])
     print("Input combined tiers file: ", combined)
-    print("Mandatory columns: ", ['GENOMIC_CHANGE', 'VCF_SAMPLE_ID'])
+    print("Mandatory columns: ", ['GENOMIC_CHANGE', 'VCF_SAMPLE_ID', 'SYMBOL', 'PROTEIN_CHANGE'])
     print("Extra columns to include: ", columns)
     
-    final_columns = ['VCF_SAMPLE_ID']
+    final_columns = ['VCF_SAMPLE_ID', 'SYMBOL', 'PROTEIN_CHANGE']
 
     for column in columns:
         if column not in PCGR_COLUMNS:

--- a/bin/report.Rmd
+++ b/bin/report.Rmd
@@ -10,7 +10,8 @@ output:
     highlight: tango           # specifies the syntax highlighting style
     css: 'style.css'
 params:
-  ptable_gene: "pivot_gene.tsv"
+  ptable_gene_simple: "pivot_gene_simple.tsv"
+  ptable_gene_complete: "pivot_gene_complete.tsv"
   ptable_variant: "pivot_variant.tsv"
   pplot_tiers: "tiers.png"
 title: "`r paste0('PCGR-nf Report' , '') `"
@@ -37,6 +38,7 @@ library(dplyr)
 library(kableExtra)
    })
 ```
+
 ## Summary Plots
 
 ```{r, warning=FALSE}
@@ -52,8 +54,17 @@ htmltools::tags$figcaption( style = 'caption-side: bottom; text-align: center; f
 
 ### By Gene
 
+#### Gene
+
 ```{r, warning=FALSE}
-table_genes <- as.data.frame(data.table::fread(params$ptable_gene, sep="\t"))
+table_genes <- as.data.frame(data.table::fread(params$ptable_gene_simple, sep="\t"))
+DTable(table_genes)
+```
+
+#### Gene, Variant Class and Consequence
+
+```{r, warning=FALSE}
+table_genes <- as.data.frame(data.table::fread(params$ptable_gene_complete, sep="\t"))
 DTable(table_genes)
 ```
 

--- a/main.nf
+++ b/main.nf
@@ -283,7 +283,7 @@ if (report_mode == 'report') {
         file("pivot_gene.tsv") into pivot_tiers_gene
 
         script:
-        "python pivot_gene.py $tiers $task.cpus"
+        "python pivot_gene.py $tiers ${params.columns_genes} $task.cpus"
     }
 
     process pivot_table_variant {
@@ -298,7 +298,7 @@ if (report_mode == 'report') {
         file("pivot_variant.tsv") into pivot_tiers_variant
 
         script:
-        "python pivot_variant.py $tiers ${params.pivot_columns_variants} $task.cpus"
+        "python pivot_variant.py $tiers ${params.columns_variants} $task.cpus"
     }
 
     process plot_tiers {

--- a/nextflow.config
+++ b/nextflow.config
@@ -170,7 +170,7 @@ process {
     }
 
     withName: plot_tiers {
-      container = 'quay.io/lifebitai/pcgr:python-base_1.0.0'
+      container = 'python_m1:latest'
     }
 
     withName: summary {

--- a/nextflow.config
+++ b/nextflow.config
@@ -80,8 +80,9 @@ params {
     report_mode = "summary"
 
     // summary options:
-    // - Columns for summary table, separated by a comma
-    pivot_columns_variants = "VARIANT_CLASS,CONSEQUENCE,TIER,TIER_DESCRIPTION"
+    // - Columns for summary tables, separated by a comma
+    columns_genes = false
+    columns_variants = "VARIANT_CLASS,CONSEQUENCE,TIER,TIER_DESCRIPTION"
     
     // report_dir is:
     // - the folder from the container that includes the scripts for NF <= v20.01 (bin)

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,7 +81,8 @@ params {
 
     // summary options:
     // - Columns for summary tables, separated by a comma
-    columns_genes = false
+    columns_genes_simple = false
+    columns_genes_complete = false
     columns_variants = "VARIANT_CLASS,CONSEQUENCE,TIER,TIER_DESCRIPTION"
     
     // report_dir is:
@@ -161,7 +162,11 @@ process {
       container = 'quay.io/biocontainers/vcflib:1.0.2--h3198e80_5'
     }
 
-    withName: pivot_table_gene {
+    withName: pivot_table_gene_simple {
+      container = 'quay.io/lifebitai/pcgr:python-base_1.0.0'
+    }
+
+    withName: pivot_table_gene_complete {
       container = 'quay.io/lifebitai/pcgr:python-base_1.0.0'
     }
 
@@ -170,7 +175,7 @@ process {
     }
 
     withName: plot_tiers {
-      container = 'python_m1:latest'
+      container = 'quay.io/lifebitai/pcgr:python-base_1.0.0'
     }
 
     withName: summary {


### PR DESCRIPTION
This PR closes #31 and #32 and add a new table of gene summary required for #29

## Modifications:

- The Summary Table has two sections: by gene and by variant. The "by gene " section now features two tables
  - Gene - containing basic information on each gene with variants, are requested in #29. This table will later on display the metadata passed to the pcgr-nf workflow

![image](https://user-images.githubusercontent.com/73831087/129933292-2443da11-c107-44dd-afd8-63ddae3e8fcd.png)

  - Gene, Variant Class and Consequence - Addition of two columns, ONCOGENE and TUMOR_SUPPRESSOR, as requested in #31 

![image](https://user-images.githubusercontent.com/73831087/129933356-d9ed05ec-e966-43bd-ba47-ce2fe3bdfd42.png)

- Variant table as before with the addition of two columns: Gene symbol, and protein change, as requested in #32 

![image](https://user-images.githubusercontent.com/73831087/129933440-5ea32b4b-4f73-4447-952d-75405ae965dd.png)


## To test:

To test the pipeline with new test and reference data locally run:

    git clone https://github.com/lifebit-ai/pcgr-nf
    cd pcgr-nf
    git checkout upd-test-and-docs
    NXF_VER=20.01.0 nextflow run . -profile standard,docker --config conf/test.config


### Runed locally 
![image](https://user-images.githubusercontent.com/73831087/129933019-7f0faddf-299e-4b00-877b-ab1cef192459.png)
`git log -1`
![image](https://user-images.githubusercontent.com/73831087/129933209-c717166e-5589-4ce0-8025-c4984e30a31e.png)


### Runed on CloudOS

Public run with the latest commit id available at https://cloudos.lifebit.ai/app/jobs/611d2e037db707019a08d6f2 
![image](https://user-images.githubusercontent.com/73831087/129936778-9a968d7c-cebe-405d-8899-aa1aa5ee4b30.png)
![image](https://user-images.githubusercontent.com/73831087/129936823-a9f542b8-857d-4f08-b275-e4d160f9e612.png)
![image](https://user-images.githubusercontent.com/73831087/129936903-e1c63930-aed0-4324-9159-8951d55b7a70.png)
