### PR TITLE
Add option to display metadata 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ work/
 results/
 .DS_Store
 *.tsv
+*.csv

--- a/bin/combine.py
+++ b/bin/combine.py
@@ -23,7 +23,7 @@ def __main__():
 
         df = pd.concat(li, axis=0, ignore_index=True)
     
-    if metadata != "null":
+    if metadata != "PASS":
         # process metadata
         metadata_df = pd.read_csv(metadata, index_col=None, header=0, delimiter=",")
         metadata_df = metadata_df.add_prefix("metadata_")

--- a/bin/combine.py
+++ b/bin/combine.py
@@ -3,28 +3,38 @@
 import os
 import sys
 import shutil
+import pandas as pd
 
 def __main__():
     
-    pcgr_tsvs = sys.argv[1:]
+    metadata = sys.argv[1]
+    pcgr_tsvs = sys.argv[2:]
     print("Input tsv files:", pcgr_tsvs)
+    print("Metadata: ", metadata)
 
     if len(pcgr_tsvs) == 1:
-        shutil.copyfile(pcgr_tsvs[0], "combined.tsv", follow_symlinks=True)
+        df = pd.read_csv(pcgr_tsvs[0], index_col=None, header=0, delimiter="\t")
     else:
-        with open("combined.tiers.tsv", "w") as combined_fh:
-            for tsvfile in pcgr_tsvs:
-                with open(tsvfile, "r") as tsv_fh:
-                    #check if first file - only copy the header once
-                    if pcgr_tsvs.index(tsvfile) == 0:
-                        #get header line, add sample column at the start
-                        first_line = tsv_fh.readline().split('\t')
-                        combined_fh.write('\t'.join(first_line))
-                    else:
-                        #skip first line
-                        tsv_fh.readline()
-                    for line in tsv_fh:
-                        line = line.split('\t')
-                        combined_fh.write('\t'.join(line))
+        df = pd.DataFrame()
+        li =[]
+        for tsv_file in pcgr_tsvs:
+            df_ = pd.read_csv(tsv_file, index_col=None, header=0, delimiter="\t")
+            li.append(df_)
+
+        df = pd.concat(li, axis=0, ignore_index=True)
+    
+    if metadata != "null":
+        # process metadata
+        metadata_df = pd.read_csv(metadata, index_col=None, header=0, delimiter=",")
+        metadata_df = metadata_df.add_prefix("metadata_")
+        metadata_df['VCF_SAMPLE_ID'] = metadata_df['metadata_vcf'].str.replace('.vcf', '')
+        metadata_df = metadata_df.drop(columns='metadata_vcf')
+        metadata_df.columns = map(str.upper, metadata_df.columns)
+
+        df = df.merge(metadata_df, on='VCF_SAMPLE_ID', how="left")
+        print(df)
+
+    # save final file
+    df.to_csv("combined.tiers.tsv", sep="\t", index=False, na_rep="NA") 
 
 if __name__=="__main__": __main__()

--- a/bin/pivot_gene_complete.py
+++ b/bin/pivot_gene_complete.py
@@ -25,13 +25,17 @@ def process(group_name, df_group):
     Worker function to process the dataframe.
     """
     row = {'SYMBOL'.capitalize(): group_name[0],
-            'GENE_NAME'.capitalize(): group_name[1],
-            'VARIANT CLASS'.capitalize(): group_name[2],
-            'CONSEQUENCE'.capitalize(): group_name[3]}
+        'GENE NAME'.capitalize(): group_name[1]}
+    row['ONCOGENE'.capitalize()] = ";".join([str(x) for x in list(df_group['ONCOGENE'].unique())])
+    row['TUMOR_SUPPRESSOR'.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group['TUMOR_SUPPRESSOR'].unique())])
+    
     for column in df_group.columns:
-        if column not in ['SYMBOL', 'GENE_NAME', 'VARIANT_CLASS', 'CONSEQUENCE']:
+        if column not in ['SYMBOL', 'GENE_NAME', 'VARIANT_CLASS', 'CONSEQUENCE',  'ONCOGENE', 'TUMOR_SUPPRESSOR']:
             row[column.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group[column].unique())])
+    
     row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'].unique())))
+    row['VARIANT CLASS'.capitalize()] = group_name[2]
+    row['CONSEQUENCE'.capitalize()] =  group_name[3]
     return row
 
 
@@ -45,7 +49,7 @@ def __main__():
         columns = sys.argv[2].split(',')
     max_cpus = int(sys.argv[3])
 
-    mandatory_columns = ['GENE_NAME','SYMBOL', 'VARIANT_CLASS', 'CONSEQUENCE', 'ONCOGENE', 'TUMOR_SUPPRESSOR', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
+    mandatory_columns = ['GENE_NAME','SYMBOL', 'ONCOGENE', 'TUMOR_SUPPRESSOR', 'VARIANT_CLASS', 'CONSEQUENCE', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
 
     print("Input combined tiers file:", combined)
     print("Mandatory columns", mandatory_columns)

--- a/bin/pivot_gene_simple.py
+++ b/bin/pivot_gene_simple.py
@@ -7,7 +7,6 @@ import shutil
 import pandas as pd
 import multiprocessing as mp
 
-
 PCGR_COLUMNS = ['CHROM','POS','REF','ALT','GENOMIC_CHANGE','GENOME_VERSION','VCF_SAMPLE_ID',
                 'VARIANT_CLASS','SYMBOL','GENE_NAME','CCDS','CANONICAL','ENTREZ_ID','UNIPROT_ID',
                 'ENSEMBL_TRANSCRIPT_ID','ENSEMBL_GENE_I','REFSEQ_MRNA','ONCOGENE','TUMOR_SUPPRESSOR',
@@ -20,53 +19,85 @@ PCGR_COLUMNS = ['CHROM','POS','REF','ALT','GENOMIC_CHANGE','GENOME_VERSION','VCF
                 'CALL_CONFIDENCE','DP_TUMOR','AF_TUMOR','DP_CONTROL','AF_CONTROL','TIER','TIER_DESCRIPTION']
 
 
-def process(group_name, df_group):
+def process(group_name, df_group, metadata):
     """
     Worker function to process the dataframe.
     """
     row = {'SYMBOL'.capitalize(): group_name[0],
-            'GENE_NAME'.capitalize(): group_name[1]}
+            'GENE NAME'.capitalize(): group_name[1]}
     for column in df_group.columns:
         if column not in ['SYMBOL', 'GENE_NAME', 'GENOMIC_CHANGE']:
             row[column.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group[column].unique())])
     row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'].unique())))
+    if not metadata.empty:
+        summed_values = pd.DataFrame(columns=sorted(metadata.columns))
+        for sample in row['VCF SAMPLE ID'.capitalize()].split(';'):
+            summed_values = summed_values.append(metadata.loc[sample])
+        for col in summed_values.columns:
+            row[col.replace('_', ' ').capitalize()] = int(sum(summed_values[col]))
     return row
 
 
 def __main__():
 
+    # input
     combined = sys.argv[1]
+    combined_header = open(combined).readline().rstrip().split("\t")
+
     columns = sys.argv[2]
     if columns == 'false':
         columns = []
     else:
         columns = sys.argv[2].split(',')
+
     max_cpus = int(sys.argv[3])
 
+    # columns for report
     mandatory_columns = ['GENE_NAME','SYMBOL', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
+    metadata_col = [col for col in combined_header if col.startswith('METADATA_')]
 
     print("Input combined tiers file:", combined)
     print("Mandatory columns", mandatory_columns)
     print("Extra columns to include:", columns)
+    print("Metadata columns: ", metadata_col)
 
+    # create dataframe with value counts per metadata 
+    metadata_col = ['VCF_SAMPLE_ID'] + metadata_col
+    metadata_df = pd.read_csv(combined, sep='\t', header=0, usecols=metadata_col).drop_duplicates()
+
+    group_metadata_df = metadata_df.groupby(['VCF_SAMPLE_ID'])
+    metadata_rows = []
+    for group_name, df_group in group_metadata_df:
+        row = {'VCF SAMPLE ID'.capitalize(): group_name}
+        for col in df_group.columns:
+            _count_dict = json.loads((df_group[col].value_counts().to_json()))
+            for k,v in _count_dict.items():
+                if k != group_name:
+                    row['Number_'+k] = v 
+        metadata_rows.append(row)
+    count_metadata_df = pd.DataFrame([f for f in metadata_rows]).fillna(0).set_index('VCF SAMPLE ID'.capitalize()) 
+
+    # parse and process pcgr combined file
     all_columns = list(set(mandatory_columns + columns))
-        
     reader = pd.read_csv(combined, sep='\t', header=0, chunksize=1000, usecols=all_columns)
     chunk_arr = []
     for df in reader:
         chunk_arr.append(df)
     df = pd.concat(chunk_arr, axis=0)
 
+    # combine information per gene
     group_by = df.groupby(['SYMBOL','GENE_NAME'])
     print("Number of genes found:", len(group_by))
 
     pool = mp.Pool(processes=max_cpus)
     f_list = []
     for group_name, df_group in group_by:
-        f = pool.apply_async(process, [group_name, df_group])
+        f = pool.apply_async(process, [group_name, df_group, count_metadata_df])
         f_list.append(f)
 
     pivot = pd.DataFrame([f.get() for f in f_list]) 
+
+
     pivot.to_csv("pivot_gene_simple.tsv", sep='\t', index=False)
 
 if __name__=="__main__": __main__()

--- a/bin/pivot_gene_simple.py
+++ b/bin/pivot_gene_simple.py
@@ -37,12 +37,12 @@ def process(group_name, df_group, metadata):
     
     if not metadata.empty:
         summed_values = pd.DataFrame(columns=sorted(metadata.columns))
-        total = metadata.sum().sum()
         for sample in row['VCF SAMPLE ID'.capitalize()].split(';'):
             summed_values = summed_values.append(metadata.loc[sample])
         for col in summed_values.columns:
+            total_category = metadata[col].sum()
             row[col.replace('_', ' ').capitalize()] = int(sum(summed_values[col]))
-            row[col.replace('_', ' ').replace('Number',"Percentage").capitalize()] = sum(summed_values[col])/total * 100
+            row[col.replace('_', ' ').replace('Number',"Percentage").capitalize()] = sum(summed_values[col])/total_category * 100
     return row
 
 

--- a/bin/pivot_gene_simple.py
+++ b/bin/pivot_gene_simple.py
@@ -30,10 +30,16 @@ def process(group_name, df_group, metadata):
     row['TUMOR_SUPPRESSOR'.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group['TUMOR_SUPPRESSOR'].unique())])
 
     for column in df_group.columns:
-        if column not in ['SYMBOL', 'GENE_NAME', 'GENOMIC_CHANGE', 'ONCOGENE', 'TUMOR_SUPPRESSOR']:
+        if column not in ['SYMBOL', 'GENE_NAME', 'GENOMIC_CHANGE', 'ONCOGENE', 'TUMOR_SUPPRESSOR', 'TIER']:
             row[column.replace('_', ' ').capitalize()] = ";".join([str(x) for x in list(df_group[column].unique())])
     
-    row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'].unique())))
+    row['NUMBER OF VARIANTS'.capitalize()] = str(len(list(df_group['GENOMIC_CHANGE'])))
+
+    row["Tier 1"] = len(df_group['TIER'][df_group['TIER']=="TIER 1"])
+    row["Tier 2"] = len(df_group['TIER'][df_group['TIER']=="TIER 2"])
+    row["Tier 3"] = len(df_group['TIER'][df_group['TIER']=="TIER 3"])
+    row["Tier 4"] = len(df_group['TIER'][df_group['TIER']=="TIER 4"])
+    row["Noncoding"] = len(df_group['TIER'][df_group['TIER']=="NONCODING"])
     
     if not metadata.empty:
         summed_values = pd.DataFrame(columns=sorted(metadata.columns))
@@ -61,7 +67,7 @@ def __main__():
     max_cpus = int(sys.argv[3])
 
     # columns for report
-    mandatory_columns = ['GENE_NAME','SYMBOL', 'ONCOGENE','TUMOR_SUPPRESSOR', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE']
+    mandatory_columns = ['GENE_NAME','SYMBOL', 'ONCOGENE','TUMOR_SUPPRESSOR', 'VCF_SAMPLE_ID', 'GENOMIC_CHANGE', 'TIER']
 
     print("Input combined tiers file:", combined)
     print("Mandatory columns", mandatory_columns)

--- a/bin/report.Rmd
+++ b/bin/report.Rmd
@@ -3,7 +3,7 @@ output:
   html_document:
     code_download: false
     toc: true                  # table of content true
-    toc_depth: 3               # upto three depths of headings (specified by #, ## and ###)
+    toc_depth: 5               # upto five depths of headings (specified by #, ## and ###)
     toc_float: true
     number_sections: true      # if you want number sections at each table header
     theme: united              # many options for theme.

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,6 +1,6 @@
 params {
     csv = "s3://lifebit-featured-datasets/pipelines/pcgr/testdata/test_1/testdata.csv"
-    metadata = 'testdata/metadata.tsv'
+    metadata = "$baseDir/testdata/metadata.csv"
     genome = 'grch38'
 
     max_cpus = 2

--- a/docs/usage_cloudos.md
+++ b/docs/usage_cloudos.md
@@ -28,7 +28,7 @@ While you will be able to provide a single VCF to the pipeline simply by using t
 
 To provide more than one VCF to be analysed pipeline, it's required to use a CSV file that provides paths to all vcf files. You can create this file locally and upload it to CloudOS as any other file.
 
-The CSV file used for the test run - [testdata/testdata.csv](https://github.com/lifebit-ai/pcgr-nf/blob/upd-test-and-docs/testdata/testdata.csv)
+The CSV file used for the test run - [testdata/testdata.csv](https://github.com/lifebit-ai/pcgr-nf/blob/dev/testdata/testdata.csv)
 
 An example csv file:
 `my_vcf_list.csv`:
@@ -43,6 +43,25 @@ s3://my-bucket/full/path/to/my_vcf_3.vcf
 You can then provide this CSV file to the pipeline with a `--csv my_vcf_list.csv` option.
 
 To get the S3 paths of files uploaded to CloudOS you can click the *"Text file"* blue icon on the very right from the file name in Data & Results page. This will copy the S3 path to your clipboard, and you will be able to paste it to the CSV file you are creating. For the files located on an external S3 bucket you should use their full URIs as shown in example CSV above.
+
+### 2.3 Providing metadata for multiple VCFs
+
+If you use the `--csv` option to pass a list of VCF files to pcgr-nf, you can also pass metadata for each of the samples in your CSV file using `--metadata metadata.csv`. This is an optional parameter but it's only usable is the `--csv` option is used.
+
+The metadata file used for the test run - [testdata/metadata.csv](https://github.com/lifebit-ai/pcgr-nf/blob/dev/testdata/metadata.csv)
+
+An example metadata file:
+`metadata.csv`:
+
+``` bash
+vcf,sample_id,histological_type,sex,library_name
+my_vcf_1.vcf,G1,Germinoma,female,IGCT-1
+my_vcf_2.vcf,G2,Mixed,male,IGCT-3
+my_vcf_3.vcf,G2,Mixed,female,IGCT-3
+```
+
+The `vcf` and the `histological_type` columns are **mandatory** and must be included in your metadata file. The `vcf` column must match the filenames in the one used with the `--csv` option.
+
 <br>
 <br>
 

--- a/main.nf
+++ b/main.nf
@@ -263,7 +263,8 @@ process combine_tiers {
     file("combined.tiers.tsv") into (combined_tiers_gene_simple, combined_tiers_gene_complete, combined_tiers_variant, combined_tiers_plot)
 
     script:
-    "python combine.py $metadata $tables"
+    optional_metadata = params.metadata ? "$metadata": "PASS"
+    "python combine.py $optional_metadata $tables"
 }
 
 if (report_mode == 'report') {
@@ -297,7 +298,8 @@ if (report_mode == 'report') {
         file("pivot_gene_simple.tsv") into pivot_tiers_gene_simple
 
         script:
-        "python pivot_gene_simple.py $tiers ${params.columns_genes_simple} $task.cpus"
+        metadata_opt = params.metadata ? "true": "false"
+        "python pivot_gene_simple.py $tiers ${params.columns_genes_simple} $task.cpus $metadata_opt"
     }
 
     process pivot_table_gene_complete {

--- a/main.nf
+++ b/main.nf
@@ -30,6 +30,7 @@ def helpMessage() {
                     Available only when using --csv mode
                     Should be a `*.csv` file with the first column called `vcf` and the path to each file, one per line,
                     matching the file in --csv, followed by metadata, one per column, for each sample. 
+                    The column `histological_type` is required to be present.
                     See example in `testdata/metadata.csv`.
 
     Resource Options:

--- a/testdata/metadata.csv
+++ b/testdata/metadata.csv
@@ -1,0 +1,3 @@
+vcf,sample_id,histological_type,sex,library_name
+test.vcf,G1,Germinoma,female,IGCT-1
+two.vcf,G2,Germinoma,male,IGCT-3

--- a/testdata/metadata.csv
+++ b/testdata/metadata.csv
@@ -1,3 +1,3 @@
 vcf,sample_id,histological_type,sex,library_name
 test.vcf,G1,Germinoma,female,IGCT-1
-two.vcf,G2,Germinoma,male,IGCT-3
+two.vcf,G2,Mixed,male,IGCT-3

--- a/testdata/metadata.tsv
+++ b/testdata/metadata.tsv
@@ -1,3 +1,0 @@
-vcf	sample_id	histological_type	sex	library_name
-test.vcf	G1	Germinoma	female	IGCT-1
-two.vcf	G2	Germinoma	male	IGCT-3


### PR DESCRIPTION
This PR closes #27 .
It incorporates the requirements requested in #33, #45, #46, #42 and #44 , closing them.  

## Modification:

A new optional parameter has been added `--metadata`, that allows metadata in a csv format to be passed on to pcgr-nf **when** the `--csv` option is used. The help message has been update to reflect this change:

        nextflow run main.nf --help
        N E X T F L O W  ~  version 20.10.0
        Launching `main.nf` [small_jang] - revision: 8f1fcf9600
        Usage:
        The typical command for running the pipeline is as follows:
        nextflow run main.nf --vcf sample.vcf [Options]
        
        Essential paramenters:
          Single File Mode:
        --vcf           Input `VCF` file.
                      See example in `testdata/test.vcf`. 
        
          Multiple File Mode:
        --csv           A list of `VCF` files.
                      Should be a `*.csv` file with a header called `vcf` and the path to each file, one per line. 
                      See example in `testdata/list-vcf-files-local.csv`.
        
        PCGR Options:
        --pcgr_config   Tool config file (path)
                      (default: s3://fast-ngs/cloudos-public-data-ines/pcgr.toml)
        --pcgr_genome   Reference genome assembly
                      (default: grch38)
        --pcgr_data     URL for reference data bundle.
                      Optional filed. If not provided, the appropriate data bundle is infered from --pcgr_genome. 
                      (default: grch38)
        
        Optional paramenters:
        --metadata      `CSV` file with metadata information.
                      Available only when using --csv mode
                      Should be a `*.csv` file with the first column called `vcf` and the path to each file, one per line,
                      matching the file in --csv, followed by metadata, one per column, for each sample. 
                      The column `histological_type` is required to be present.
                      See example in `testdata/metadata.csv`.
        
        Resource Options:
        --max_cpus      Maximum number of CPUs (int)
                      (default: 16)  
        --max_memory    Maximum memory (memory unit)
                      (default: 20 GB)
        --max_time      Maximum time (time unit)
                      (default: 10d)
        See here for more info: https://github.com/lifebit-ai/pcgr-nf

The metadata is combined with the main `combined.tiers.tsv` output from PCGR, identified with the prefix `METADATA_` as to avoid possible conflict with existing columns and to facilitate search and query.  
![image](https://user-images.githubusercontent.com/73831087/130996606-87251902-191a-45f6-815a-5b21f8f0eecb.png)

As described in #40, the metadata is displayed in the gene summary table, containing basic information on each gene with variants
![image](https://user-images.githubusercontent.com/73831087/130994564-afb453c3-5f6b-4dce-812c-b0c72d33677e.png)
To this table it was also added the number of variants per tier
![image](https://user-images.githubusercontent.com/73831087/130994667-9628838b-5af2-4370-95ad-c85b2e3031bc.png)
In addition to the Number and Percentage of samples according to the categories defined in the `histological_type` column in the metadata. This, alognside `vcf`,  is a required column. 

|vcf     |sample_id|histological_type|sex   |library_name|
|--------|---------|-----------------|------|------------|
|test.vcf|G1       |Germinoma        |female|IGCT-1      |
|two.vcf |G2       |Mixed            |male  |IGCT-3      |

![image](https://user-images.githubusercontent.com/73831087/130995340-b77d2ce2-ba76-46c6-87ad-40a44b649b51.png)

## To test:

To test the pipeline with new test and reference data locally run:

    git clone https://github.com/lifebit-ai/pcgr-nf
    cd pcgr-nf
    git checkout metadata-dev
    NXF_VER=20.01.0 nextflow run . -profile standard,docker --config conf/test.config


### Runed locally 
![image](https://user-images.githubusercontent.com/73831087/130994114-74ac91ca-b41f-4e06-bdc4-71d31b8905ee.png)
![image](https://user-images.githubusercontent.com/73831087/130995593-e597a633-169a-4ea0-a300-d8962575badf.png)

### Runed on CloudOS
Public run with the latest commit id available at https://cloudos.lifebit.ai/public/jobs/6127bfc47db707019a0aab6a
![image](https://user-images.githubusercontent.com/73831087/130995802-4f02687a-e7af-48aa-961f-4d2423d62be6.png)
![image](https://user-images.githubusercontent.com/73831087/131003904-0bdb661f-ecbb-4c53-a64c-2017dc1f7f23.png)
![image](https://user-images.githubusercontent.com/73831087/131003963-7591bd66-8185-4531-8304-34d2a27bcb1f.png)


