### PR TITLE
remove duplicated variants from plot

### DIFF
--- a/bin/report.Rmd
+++ b/bin/report.Rmd
@@ -3,7 +3,7 @@ output:
   html_document:
     code_download: false
     toc: true                  # table of content true
-    toc_depth: 5               # upto five depths of headings (specified by #, ## and ###)
+    toc_depth: 5               # up to five depths of headings (specified by #, ## and ###)
     toc_float: true
     number_sections: true      # if you want number sections at each table header
     theme: united              # many options for theme.
@@ -39,11 +39,13 @@ library(kableExtra)
    })
 ```
 
+This is the summary report for for variant interpretation for precision cancer medicine using [Personal Cancer Genome Reporter (PCGR)](https://github.com/sigven/pcgr). Here you can see the summary information for somatic variants annotated, as well as by-gene and by-variant level information.
+
 ## Summary Plots
 
 ```{r, warning=FALSE}
 figure_number  <- "Figure 1: "
-figure_caption <- "PCGR Tiers - Number of variants"
+figure_caption <- "PCGR Tiers - Number of unique variants per tier"
 knitr::include_graphics(params$pplot_tiers, )
 htmltools::tags$figcaption( style = 'caption-side: bottom; text-align: center; font-size: 85%%; color: #71879d',
                             htmltools::em(figure_number),

--- a/bin/tiers_plot.py
+++ b/bin/tiers_plot.py
@@ -23,12 +23,15 @@ def __main__():
 
     print("Input combined tiers file: ", combined)
     
-    reader = pd.read_csv(combined, sep='\t', header=0, chunksize=1000, usecols=['TIER'])
+    reader = pd.read_csv(combined, sep='\t', header=0, chunksize=1000, usecols=['TIER', 'GENOMIC_CHANGE'])
 
     chunk_arr = []
     for df in reader:
         chunk_arr.append(df)
     df = pd.concat(chunk_arr, axis=0)
+
+    # remove duplicated variants
+    df = df.drop_duplicates()
 
     counts = {}
     tiers = df['TIER'].value_counts()


### PR DESCRIPTION
This PR addresses the question raised in #48 where the summary plot was showing the total number of variants per tier, regardless if they were duplications. This has been corrected and the plot now matches the by-variant table, showing only the total number of unique variants per tier.

There for this plot has been changed from
![image](https://user-images.githubusercontent.com/73831087/135272158-fd82cfed-ff74-4566-bda0-4b1a001829ec.png)
to
![image](https://user-images.githubusercontent.com/73831087/135272225-77cd4837-2403-428c-a90e-a145cce24c5b.png)
matching the by-variant table (using Tier 3 as example)
![image](https://user-images.githubusercontent.com/73831087/135272391-8264be4f-51f6-4b82-afa1-bd51156c700a.png)
